### PR TITLE
Log the correct error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -218,7 +218,7 @@ function getOplogCollection (db, log) {
         log(error)
         db.collection('oplog.$main', {strict: true}, (error2, mainOplog) => {
           if (error2) {
-            log(error)
+            log(error2)
             return reject(new Error('Could not find oplog collection. Make sure mongodb is configured for replication'))
           }
           resolve(mainOplog)


### PR DESCRIPTION
Logging the same error twice in a row probably wasn't intentional here.